### PR TITLE
add version information to package

### DIFF
--- a/BayesCCal/__init__.py
+++ b/BayesCCal/__init__.py
@@ -1,3 +1,3 @@
-
 from .BayesCCal import *
 
+__version__ = "0.1"

--- a/setup.py
+++ b/setup.py
@@ -1,11 +1,29 @@
 #!/usr/bin/env python
+import codecs
+import os.path
 from distutils.core import setup
 
+
+def read(rel_path):
+    here = os.path.abspath(os.path.dirname(__file__))
+    with codecs.open(os.path.join(here, rel_path), 'r') as fp:
+        return fp.read()
+
+
+def get_version(rel_path):
+    for line in read(rel_path).splitlines():
+        if line.startswith('__version__'):
+            delim = '"' if '"' in line else "'"
+            return line.split(delim)[1]
+    else:
+        raise RuntimeError("Unable to find version string.")
+
+
 setup(name='BayesCCal',
-      version='0.1',
+      version=get_version("BayesCCal/__init__.py"),
       description='Bayesian calibration of classifiers',
       author='Marco Puts',
       author_email='mputs@acm.org',
       packages=['BayesCCal'],
-      install_requires=['numpy','scipy']
+      install_requires=['numpy', 'scipy']
      )


### PR DESCRIPTION
With this PR the package version can be queried from python:

```
import BayesCCal
print(BayesCCal.__version__)
```

For a version bump, the version information has to be updated in the file `BayesCCal/__init__.py`